### PR TITLE
add browser tests and assure consistency between browser and server

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="node" />
-export declare const kdf: (secret: Buffer, outputLength: number) => Buffer;
+export declare const kdf: (secret: Buffer, outputLength: number) => Promise<Buffer>;
 /**
  * Compute the public key for a given private key.
  *

--- a/lib/src/typescript/browser.ts
+++ b/lib/src/typescript/browser.ts
@@ -234,8 +234,8 @@ export const decrypt = (privateKey: Buffer, encrypted: Buffer): Promise<Buffer> 
     new Promise((resolve, reject) => {
         if (encrypted.length <= metaLength)
             reject(new Error(`Invalid Ciphertext. Data is too small. It should ba at least ${metaLength} bytes`))
-        else if (encrypted[0] !== 2 && encrypted[0] !== 3 && encrypted[0] !== 4)
-            reject(new Error(`Not a valid ciphertext. It should begin with 2, 3 or 4 but actualy begin with ${encrypted[0]}`))
+        else if (encrypted[0] !== 4)
+            reject(new Error(`Not a valid ciphertext. It should begin with 4 but actualy begin with ${encrypted[0]}`))
         else {
             // deserialise
             const ephemPublicKey = encrypted.slice(0, 65)

--- a/lib/src/typescript/browser.ts
+++ b/lib/src/typescript/browser.ts
@@ -52,8 +52,8 @@ const randomBytes = (size: number): Buffer =>
     crypto.getRandomValues(Buffer.alloc(size))
 
 // Get the browser SHA256 implementation
-const sha256 = (msg: Int8Array | Int16Array | Int32Array | Uint8Array | Uint16Array | Uint32Array | Uint8ClampedArray | Float32Array | Float64Array | DataView | ArrayBuffer): PromiseLike<Buffer> =>
-    subtle.digest({ name: "SHA-256" }, msg).then(Buffer.from)
+const sha256 = (msg: Int8Array | Int16Array | Int32Array | Uint8Array | Uint16Array | Uint32Array | Uint8ClampedArray | Float32Array | Float64Array | DataView | ArrayBuffer): Promise<Buffer> =>
+    subtle.digest({ name: "SHA-256" }, msg).then(Buffer.from) as Promise<Buffer>
 
 // The KDF as implemented in Parity mimics Geth's implementation
 export const kdf = (secret: Buffer, outputLength: number): Promise<Buffer> => {
@@ -72,20 +72,27 @@ export const kdf = (secret: Buffer, outputLength: number): Promise<Buffer> => {
     return willBeResult;
 }
 
-// Get the AES-128-CTR browser implementation
-const getAes = (op: typeof subtle.encrypt | typeof subtle.decrypt) => (
-    counter: Buffer,
-    key: Int8Array | Int16Array | Int32Array | Uint8Array | Uint16Array | Uint32Array | Uint8ClampedArray | Float32Array | Float64Array | DataView | ArrayBuffer,
-    data: Int8Array | Int16Array | Int32Array | Uint8Array | Uint16Array | Uint32Array | Uint8ClampedArray | Float32Array | Float64Array | DataView | ArrayBuffer
-) =>
-    subtle
-        .importKey("raw", key, "AES-CTR", false, [op.name])
-        .then(cryptoKey =>
-            op({ name: "AES-CTR", counter: counter, length: 128 }, cryptoKey, data)
-        ).then(Buffer.from)
+const aesCtrEncrypt = (
+  counter: Buffer,
+  key: Int8Array | Int16Array | Int32Array | Uint8Array | Uint16Array | Uint32Array | Uint8ClampedArray | Float32Array | Float64Array | DataView | ArrayBuffer,
+  data: Int8Array | Int16Array | Int32Array | Uint8Array | Uint16Array | Uint32Array | Uint8ClampedArray | Float32Array | Float64Array | DataView | ArrayBuffer
+): Promise<Buffer> =>
+  subtle
+      .importKey('raw', key, 'AES-CTR', false, ['encrypt'])
+      .then(cryptoKey =>
+        subtle.encrypt({ name: 'AES-CTR', counter: counter, length: 128 }, cryptoKey, data)
+      ).then(Buffer.from) as Promise<Buffer>
 
-const aesCtrEncrypt = getAes(subtle.encrypt)
-const aesCtrDecrypt = getAes(subtle.decrypt)
+const aesCtrDecrypt = (
+  counter: Buffer,
+  key: Int8Array | Int16Array | Int32Array | Uint8Array | Uint16Array | Uint32Array | Uint8ClampedArray | Float32Array | Float64Array | DataView | ArrayBuffer,
+  data: Int8Array | Int16Array | Int32Array | Uint8Array | Uint16Array | Uint32Array | Uint8ClampedArray | Float32Array | Float64Array | DataView | ArrayBuffer
+): Promise<Buffer> =>
+  subtle
+      .importKey('raw', key, 'AES-CTR', false, ['decrypt'])
+      .then(cryptoKey =>
+          subtle.decrypt({ name: 'AES-CTR', counter: counter, length: 128 }, cryptoKey, data)
+      ).then(Buffer.from) as Promise<Buffer>
 
 const hmacSha256Sign = (
     key: Int8Array | Int16Array | Int32Array | Uint8Array | Uint16Array | Uint32Array | Uint8ClampedArray | Float32Array | Float64Array | DataView | ArrayBuffer,
@@ -101,10 +108,10 @@ const hmacSha256Verify = (
     key: Int8Array | Int16Array | Int32Array | Uint8Array | Uint16Array | Uint32Array | Uint8ClampedArray | Float32Array | Float64Array | DataView | ArrayBuffer,
     msg: Int8Array | Int16Array | Int32Array | Uint8Array | Uint16Array | Uint32Array | Uint8ClampedArray | Float32Array | Float64Array | DataView | ArrayBuffer,
     sig: Int8Array | Int16Array | Int32Array | Uint8Array | Uint16Array | Uint32Array | Uint8ClampedArray | Float32Array | Float64Array | DataView | ArrayBuffer,
-): PromiseLike<boolean> => {
+): Promise<boolean> => {
     const algorithm = { name: "HMAC", hash: { name: "SHA-256" } }
     const keyp = subtle.importKey("raw", key, algorithm, false, ["verify"])
-    return keyp.then(cryptoKey => subtle.verify(algorithm, cryptoKey, sig, msg))
+    return keyp.then(cryptoKey => subtle.verify(algorithm, cryptoKey, sig, msg)) as Promise<boolean>
 }
 
 /**
@@ -116,7 +123,7 @@ const hmacSha256Verify = (
  */
 export const getPublic = (privateKey: Buffer): Promise<Buffer> => new Promise((resolve, reject) => {
     if (privateKey.length !== 32)
-        reject(new Error('Bad private key'))
+        reject(new Error('Private key should be 32 bytes long'))
     else
         resolve(Buffer.from(ec.keyFromPrivate(privateKey).getPublic('array')))
 })
@@ -131,11 +138,11 @@ export const getPublic = (privateKey: Buffer): Promise<Buffer> => new Promise((r
 export const sign = (privateKey: Buffer, msg: Buffer): Promise<Buffer> =>
     new Promise((resolve, reject) => {
         if (privateKey.length !== 32)
-            reject(new Error('Bad private key'))
+            reject(new Error('Private key should be 32 bytes long'))
         else if (msg.length <= 0)
             reject(new Error('Message should not be empty'))
         else if (msg.length > 32)
-            reject(new Error('Message is too long'))
+            reject(new Error('Message is too long (max 32 bytes)'))
         else
             resolve(Buffer.from(ec.sign(msg, privateKey, { canonical: true }).toDER('hex'), 'hex'))
     })
@@ -151,13 +158,13 @@ export const sign = (privateKey: Buffer, msg: Buffer): Promise<Buffer> =>
 export const verify = (publicKey: Buffer, msg: Buffer, sig: Buffer): Promise<null> =>
     new Promise((resolve, reject) => {
         if (publicKey.length !== 65 || publicKey[0] !== 4)
-            reject(new Error('Bad public key'))
+            reject(new Error('Public key should 65 bytes long'))
         else if (msg.length <= 0)
             reject(new Error('Message should not be empty'))
         else if (msg.length > 32)
-            reject(new Error('Message is too long'))
+            reject(new Error('Message is too long (max 32 bytes)'))
         else if (!ec.verify(msg, sig.toString('hex') as any, publicKey, 'hex'))
-            reject(new Error("Bad signature"))
+            reject(new Error('Bad signature'))
         else
             resolve(null)
     })
@@ -196,18 +203,22 @@ export const derive = (privateKeyA: Buffer, publicKeyB: Buffer): Promise<Buffer>
 export const encrypt = (publicKeyTo: Buffer, msg: Buffer, opts?: { iv?: Buffer, ephemPrivateKey?: Buffer }): Promise<Buffer> => {
     opts = opts || {}
     const ephemPrivateKey = opts.ephemPrivateKey || randomBytes(32)
-    const willBeSharedPx = derive(ephemPrivateKey, publicKeyTo)
-    const willBeHash = willBeSharedPx.then(sharedPx => kdf(sharedPx, 32))
-    const iv = opts.iv || randomBytes(16)
-    const willBeEncryptionKey = willBeHash.then(hash => hash.slice(0, 16))
-    const willBeMacKey = willBeHash.then(hash => sha256(hash.slice(16)))
-    const willBeCipherText = willBeEncryptionKey.then(encryptionKey => aesCtrEncrypt(iv, encryptionKey, msg))
-    const willBeIvCipherText = willBeCipherText.then(cipherText => Buffer.concat([iv, cipherText]))
-    const willBeHMAC = willBeMacKey.then(macKey => willBeIvCipherText.then(ivCipherText => hmacSha256Sign(macKey, ivCipherText)))
-    const willBeEphemPublicKey = getPublic(ephemPrivateKey)
-    return willBeEphemPublicKey.then(ephemPublicKey => willBeIvCipherText.then(ivCipherText => willBeHMAC.then(HMAC =>
-        Buffer.concat([ephemPublicKey, ivCipherText, HMAC])
-    )))
+    return derive(ephemPrivateKey, publicKeyTo)
+      .then(sharedPx => kdf(sharedPx, 32))
+      .then(hash => {
+        const iv = opts!.iv || randomBytes(16)
+        const encryptionKey = hash.slice(0, 16)
+        return aesCtrEncrypt(iv, encryptionKey, msg)
+          .then(cipherText => Buffer.concat([iv, cipherText]))
+          .then(ivCipherText =>
+            sha256(hash.slice(16))
+              .then(macKey => hmacSha256Sign(macKey, ivCipherText))
+              .then(HMAC =>
+                getPublic(ephemPrivateKey)
+                  .then(ephemPublicKey => Buffer.concat([ephemPublicKey, ivCipherText, HMAC]))
+              )
+          )
+      })
 }
 
 const metaLength = 1 + 64 + 16 + 32
@@ -222,8 +233,8 @@ const metaLength = 1 + 64 + 16 + 32
 export const decrypt = (privateKey: Buffer, encrypted: Buffer): Promise<Buffer> =>
     new Promise((resolve, reject) => {
         if (encrypted.length <= metaLength)
-            reject(new Error(`Invalid Ciphertext. Data is too small, should be more than ${metaLength} bytes`))
-        else if (encrypted[0] < 2 && encrypted[0] > 4)
+            reject(new Error(`Invalid Ciphertext. Data is too small. It should ba at least ${metaLength} bytes`))
+        else if (encrypted[0] !== 2 && encrypted[0] !== 3 && encrypted[0] !== 4)
             reject(new Error(`Not a valid ciphertext. It should begin with 2, 3 or 4 but actualy begin with ${encrypted[0]}`))
         else {
             // deserialise
@@ -235,20 +246,15 @@ export const decrypt = (privateKey: Buffer, encrypted: Buffer): Promise<Buffer> 
             const msgMac = encrypted.slice(65 + 16 + cipherTextLength)
 
             // check HMAC
-            const willBePx = derive(privateKey, ephemPublicKey)
-            const willBeHash = willBePx.then(px => kdf(px, 32))
-            const willBeEncryptionKey = willBeHash.then(hash => hash.slice(0, 16))
-            const willBeMacKey = willBeHash.then(hash => sha256(hash.slice(16)))
-            willBeMacKey.then(macKey => hmacSha256Verify(macKey, cipherAndIv, msgMac))
-                .then(isHmacGood => willBeEncryptionKey.then(encryptionKey => {
-                    if (!isHmacGood)
-                        reject(new Error('Incorrect MAC'))
-                    else {
-                        // decrypt message
-                        aesCtrDecrypt(iv, encryptionKey, ciphertext).then(plainText =>
-                            resolve(Buffer.from(plainText))
-                        )
-                    }
-                })).catch(reject)
+            resolve(derive(privateKey, ephemPublicKey)
+              .then(px => kdf(px, 32))
+              .then(hash => sha256(hash.slice(16)).then(macKey => [hash.slice(0, 16), macKey]))
+              .then(([encryptionKey, macKey]) => 
+                hmacSha256Verify(macKey, cipherAndIv, msgMac)
+                  .then(isHmacGood => !isHmacGood
+                    ? Promise.reject(new Error('Incorrect MAC'))
+                    : aesCtrDecrypt(iv, encryptionKey, ciphertext)
+                  )
+              ).then(Buffer.from))
         }
     })

--- a/lib/src/typescript/node.ts
+++ b/lib/src/typescript/node.ts
@@ -212,8 +212,8 @@ const metaLength = 1 + 64 + 16 + 32
 export const decrypt = (privateKey: Buffer, encrypted: Buffer): Promise<Buffer> => new Promise((resolve, reject) => {
     if (encrypted.length < metaLength)
       reject(new Error(`Invalid Ciphertext. Data is too small. It should ba at least ${metaLength}`))
-    else if (encrypted[0] !== 2 && encrypted[0] !== 3 && encrypted[0] !== 4)
-      reject(new Error(`Not a valid ciphertext. It should begin with 2, 3 or 4 but actualy begin with ${encrypted[0]}`))
+    else if (encrypted[0] !== 4)
+      reject(new Error(`Not a valid ciphertext. It should begin with 4 but actually begin with ${encrypted[0]}`))
     else {
         // deserialise
         const ephemPublicKey = encrypted.slice(0, 65)

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "browser": "dist/lib/src/typescript/browser.js",
   "scripts": {
     "build": "tsc",
-    "test": "mocha 'test/**/*.specs.ts' --require ts-node/register"
+    "test": "mocha 'test/src/typescript/node.specs.ts' --require ts-node/register && tsc && browserify ./dist/test/src/typescript/browser.specs.js -o dist/test/src/typescript/index.js && live-server --port=9001 --mount=/:test/src/typescript"
   },
   "repository": {
     "type": "git",
@@ -38,8 +38,10 @@
     "@types/node": "^12.12.21",
     "@types/secp256k1": "^3.5.0",
     "@types/typescript": "^2.0.0",
+    "browserify": "^16.5.0",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
+    "live-server": "^1.2.1",
     "mocha": "^6.2.2",
     "ts-node": "^8.5.4",
     "typescript": "^3.7.4"

--- a/test/src/typescript/browser.specs.ts
+++ b/test/src/typescript/browser.specs.ts
@@ -307,7 +307,7 @@ describe('ecies', () => {
             const encryptedWithFalsePublicKey = Buffer.from('031891f11182f69dfd67dc190ccd649445182c6474f69c9f3885c99733b056fb53e1a30b90b6d2a2624449fda885adcba50334024b20081b07f95f3cc92a93dbedccf75890cd7ac088b0810058c272ef25a4028875342c5dfc36b54f156cd26b69109625e5374bc689c79196d98ccc9ad5b7099e6484', 'hex')
             const found = ecies.decrypt(secret, encryptedWithFalsePublicKey)
 
-            return expect(found).to.be.rejectedWith(`Bad public key, a valid public key would begin with 4`)
+            return expect(found).to.be.rejectedWith(`Not a valid ciphertext. It should begin with 4 but actualy begin with 3`)
         })
         it(`should NOT accept an encrypted msg smaller than ${metaLength} bytes`, () => {
             const secret = Buffer.from('b9fc3b425d6c1745b9c963c97e6e1d4c1db7a093a36e0cf7c0bf85dc1130b8a0', 'hex')

--- a/test/src/typescript/browser.specs.ts
+++ b/test/src/typescript/browser.specs.ts
@@ -1,12 +1,10 @@
-import * as chai from 'chai'
-import 'mocha'
-import chaiAsPromised from 'chai-as-promised'
-chai.use(chaiAsPromised)
-chai.should()
-const expect = chai.expect
-
 type ECIES = typeof import('../../..') //only import type from the node
-const ecies = require('../../..') as ECIES
+const ecies = require('../../../lib/src/typescript/index') as ECIES
+
+const chaiAsPromised = require("chai-as-promised");
+chai.use(chaiAsPromised)
+
+declare function expect(val: any, message?: string): any
 
 describe('ecies', () => {
     describe('kdf', () => {
@@ -43,7 +41,7 @@ describe('ecies', () => {
             const secret = Buffer.from('b9fc3b425d6c1745b9c963c97e6e1d4c1db7a093a36e0cf7c0bf85dc1130b8a0', 'hex')
             const found = ecies.getPublic(secret)
 
-            return expect(found).to.be.fulfilled
+            return expect(found)
         })
         it('should NOT accept a smaller buffer as parameter', () => {
             const smallerSecret = Buffer.from('b9fc3b425d6c1745b9c9631d4c1db7a093a36e0cf7c0bf85dc1130b8a0', 'hex')
@@ -288,7 +286,7 @@ describe('ecies', () => {
             const encrypted = Buffer.from('041891f11182f69dfd67dc190ccd649445182c6474f69c9f3885c99733b056fb53e1a30b90b6d2a2624449fda885adcba50334024b20081b07f95f3cc92a93dbedccf75890cd7ac088b0810058c272ef25a4028875342c5dfc36b54f156cd26b69109625e5374bc689c79196d98ccc9ad5b7099e6484', 'hex')
             const found = ecies.decrypt(secret, encrypted)
 
-            return found.should.be.fulfilled
+            return expect(found)
         })
         it('should NOT accept a secret key smaller than 32 bytes', () => {
             const smallerSecret = Buffer.from('b9fc3b425d6c1745b9c963c97e6e1d4c1db7a093a37c0bf85dc1130b8a0', 'hex')
@@ -316,7 +314,7 @@ describe('ecies', () => {
             const smallerEncrypted = Buffer.from('041891f11182f69dfd67dc190c1a30b90b6d2a2624449fda885adcba50334024b20081b07f95f3cc92a93dbedccf75890cd7ac088b0810058c272ef25a4028875342c5dfc36b54f156cd26b69109625e5374bc689c79196d98ccc9ad5b7099e6484', 'hex')
             const found = ecies.decrypt(secret, smallerEncrypted)
 
-            return expect(found).to.be.rejectedWith(`Invalid Ciphertext. Data is too small. It should ba at least 113`)
+            return expect(found).to.be.rejectedWith(`Invalid Ciphertext. Data is too small. It should ba at least 113 bytes`)
         })
     })
     describe('encrypt and decrypt', () => {

--- a/test/src/typescript/index.html
+++ b/test/src/typescript/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Mocha</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="stylesheet" href="../../../node_modules/mocha/mocha.css">
+  </head>
+  <body>
+    <div id="mocha"></div>
+    <script src="../../../node_modules/mocha/mocha.js"></script>
+    <script src="../../../node_modules/chai/chai.js"></script>
+    <script src="../../../node_modules/chai-as-promised/lib/chai-as-promised.js"></script>
+    <script> mocha.setup('bdd');</script>
+    <script src="../../../dist/test/src/typescript/index.js"></script>
+    <script>
+      chai.should();
+      mocha.run();
+      var expect = chai.expect //var because we want it to be attach on top of the global object
+    </script>
+  </body>
+</html>

--- a/test/src/typescript/node.specs.ts
+++ b/test/src/typescript/node.specs.ts
@@ -309,7 +309,7 @@ describe('ecies', () => {
             const encryptedWithFalsePublicKey = Buffer.from('031891f11182f69dfd67dc190ccd649445182c6474f69c9f3885c99733b056fb53e1a30b90b6d2a2624449fda885adcba50334024b20081b07f95f3cc92a93dbedccf75890cd7ac088b0810058c272ef25a4028875342c5dfc36b54f156cd26b69109625e5374bc689c79196d98ccc9ad5b7099e6484', 'hex')
             const found = ecies.decrypt(secret, encryptedWithFalsePublicKey)
 
-            return expect(found).to.be.rejectedWith(`Bad public key, a valid public key would begin with 4`)
+            return expect(found).to.be.rejectedWith(`Not a valid ciphertext. It should begin with 4 but actualy begin with 3`)
         })
         it(`should NOT accept an encrypted msg smaller than ${metaLength} bytes`, () => {
             const secret = Buffer.from('b9fc3b425d6c1745b9c963c97e6e1d4c1db7a093a36e0cf7c0bf85dc1130b8a0', 'hex')


### PR DESCRIPTION
`getAes` is split between `aesCtrEncrypt` and `aesCtrDecrypt` which where already defined for this purpose.